### PR TITLE
NCIATWP-9362: Section 508 fixes for API Access (FORGEdb)

### DIFF
--- a/client/src/app/api-access/page.jsx
+++ b/client/src/app/api-access/page.jsx
@@ -1,18 +1,73 @@
 "use client";
+import { useEffect, useRef } from "react";
 import SwaggerUI from "swagger-ui-react"
 import spec from "./openapi.json"
 spec.servers = [{url: process.env.NEXT_PUBLIC_BASE_PATH }]
 
+// Swagger UI generates its own DOM, which ships with Section 508 / WCAG gaps:
+// icon-only buttons without discernible text and scrollable code/example blocks
+// that cannot receive keyboard focus. patchAccessibility() repairs these after
+// Swagger renders (and on later re-renders, e.g. expanding an operation or
+// toggling "Try it out"). It only adds attributes to elements that lack them,
+// so it is safe to run repeatedly.
+function patchAccessibility(root) {
+  if (!root) return;
+
+  // Copy-to-clipboard icon buttons.
+  root.querySelectorAll(".copy-to-clipboard button").forEach((btn) => {
+    if (!btn.getAttribute("aria-label")) btn.setAttribute("aria-label", "Copy to clipboard");
+    if (!btn.getAttribute("title")) btn.setAttribute("title", "Copy to clipboard");
+  });
+
+  // Ensure any remaining icon-only buttons expose discernible text.
+  root.querySelectorAll("button:not([aria-label])").forEach((btn) => {
+    if (btn.textContent.trim() || btn.getAttribute("title")) return;
+    const cls = btn.className || "";
+    let label = "Button";
+    if (cls.includes("expand-operation")) label = "Expand operation";
+    else if (cls.includes("authorize")) label = "Authorize";
+    else if (cls.includes("copy")) label = "Copy to clipboard";
+    else if (cls.includes("model-toggle")) label = "Toggle model example";
+    btn.setAttribute("aria-label", label);
+  });
+
+  // Make scrollable code / example blocks keyboard accessible.
+  root.querySelectorAll(".highlight-code, .microlight, pre").forEach((el) => {
+    if (el.hasAttribute("tabindex")) return;
+    el.setAttribute("tabindex", "0");
+    el.setAttribute("role", "region");
+    if (!el.getAttribute("aria-label")) el.setAttribute("aria-label", "Code sample");
+  });
+}
+
 export default function ApiAccess() {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const root = ref.current;
+    if (!root) return;
+    patchAccessibility(root);
+    let frame;
+    const observer = new MutationObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => patchAccessibility(root));
+    });
+    observer.observe(root, { childList: true, subtree: true });
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, []);
+
   return (
     <div className="flex-grow-1 bg-white py-4">
       <div className="container">
         <div className="row">
           <div className="col">
-            <article>
+            <article ref={ref}>
               <h1 className="fs-1 fw-light">API Access</h1>
               <hr/>
-              <SwaggerUI spec={spec} />
+              <SwaggerUI spec={spec} onComplete={() => patchAccessibility(ref.current)} />
             </article>
           </div>
         </div>

--- a/client/src/app/styles/openapi-theme.scss
+++ b/client/src/app/styles/openapi-theme.scss
@@ -10,3 +10,58 @@
 .swagger-ui .opblock.opblock-get .opblock-summary-method {
   background-color: #2a71a5 !important;
 }
+
+/* Section 508 color-contrast fixes (NCIATWP-9362).
+   Swagger UI ships several text colors that fall below the WCAG AA 4.5:1
+   threshold against their backgrounds. Darken them so the API Access
+   documentation meets contrast requirements. */
+
+/* "Execute" button: white text on #4990e2 (3.29:1) -> use dark text */
+.swagger-ui .btn.execute {
+  color: #000000 !important;
+}
+
+/* "Cancel" button text/border (#ff6060 on near-white = 2.9:1) */
+.swagger-ui .btn.cancel,
+.swagger-ui .try-out__btn.cancel {
+  color: #b00020 !important;
+  border-color: #b00020 !important;
+}
+
+/* Parameter location labels e.g. "(path)" (#808080 on #eff7ff = 3.65:1) */
+.swagger-ui .parameter__in,
+.swagger-ui .parameter__extension {
+  color: #1b1b1b !important;
+}
+
+/* Light-gray secondary text throughout operations, parameters, models and tabs */
+.swagger-ui .parameter__type,
+.swagger-ui .parameter__deprecated,
+.swagger-ui .prop-format,
+.swagger-ui .response-col_links,
+.swagger-ui .opblock-summary-path__deprecated,
+.swagger-ui .model .property.primitive,
+.swagger-ui .model-title__text,
+.swagger-ui .tab li,
+.swagger-ui .opblock-description-wrapper,
+.swagger-ui .markdown p,
+.swagger-ui .renderedMarkdown p,
+.swagger-ui .info .base-url {
+  color: #454545 !important;
+}
+
+/* Placeholder text in "Try it out" inputs */
+.swagger-ui input::placeholder,
+.swagger-ui textarea::placeholder {
+  color: #595959 !important;
+}
+
+/* Inline-styled code-sample colors that fall below AA on the dark code background */
+.swagger-ui .highlight-code pre span[style*="color: rgb(211, 99, 99)"],
+.swagger-ui .microlight span[style*="color: rgb(211, 99, 99)"] {
+  color: #ff8080 !important;
+}
+.swagger-ui .highlight-code pre span[style*="color: rgb(136, 136, 136)"],
+.swagger-ui .microlight span[style*="color: rgb(136, 136, 136)"] {
+  color: #b3b3b3 !important;
+}


### PR DESCRIPTION
## Ticket(s)
- **NCIATWP-9362** — Section 508 accessibility fixes for the FORGEdb **API Access** page

## Summary of changes
The API Access page renders `swagger-ui-react` (`openapi.json`), so all findings are in Swagger UI's generated DOM.

**`client/src/app/api-access/page.jsx`** — post-render accessibility patch (run on `onComplete` and re-applied via a debounced `MutationObserver`, since Swagger renders these lazily):
- *Buttons must have discernible text* — labels copy-to-clipboard and any remaining icon-only buttons with an `aria-label` (buttons already named via `title`, e.g. the expand/collapse arrow, are respected).
- *Scrollable region must have keyboard access* — makes code/example blocks (`.highlight-code`, `.microlight`, `pre`) keyboard-focusable (`tabindex="0"`, `role="region"`).

**`client/src/app/styles/openapi-theme.scss`** — *color contrast* overrides for Swagger's low-contrast palette:
- Cancel button (`#ff6060`, 2.9:1) → dark red
- Execute button (white on `#4990e2`, 3.29:1) → dark text
- `parameter__in` "(path)" labels (`#808080`, 3.65:1) → near-black
- plus defensive darkening of secondary grays, input placeholders, and code-sample syntax colors

## Where the reviewer can test
```bash
cd client && npm install && npm run dev   # http://localhost:3000/api-access/
```
Expand an operation → **Try it out**: the Cancel/Execute buttons and "(path)" labels meet contrast, code blocks are keyboard-focusable (Tab into them), and icon buttons have accessible names.

Automated check with **axe-core** (same engine as the 508 report), operations expanded + Try it out: **0 WCAG A/AA violations** on the API Access page.

## Additional notes
- The installed `swagger-ui-react` is newer than the audited deploy, so live violation counts differed from the ticket (contrast surfaced as ~11 vs 18; button/scrollable findings weren't tripping the newer lib). The fixes are written defensively to cover each category regardless of Swagger version.
